### PR TITLE
remove thread check from PlayerController.setCurrentVideoId

### DIFF
--- a/app/src/main/java/pl/jakubweg/PlayerController.java
+++ b/app/src/main/java/pl/jakubweg/PlayerController.java
@@ -65,9 +65,6 @@ public class PlayerController {
             return;
         }
 
-        if (Looper.myLooper() != Looper.getMainLooper()) // check if thread is not main
-            return;
-
         if (videoId.equals(currentVideoId))
             return;
 

--- a/app/src/main/java/pl/jakubweg/PlayerController.java
+++ b/app/src/main/java/pl/jakubweg/PlayerController.java
@@ -2,7 +2,6 @@ package pl.jakubweg;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
-import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Rect;
 import android.os.Handler;
@@ -10,7 +9,6 @@ import android.os.Looper;
 import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Toast;
 
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Method;


### PR DESCRIPTION
while i realize that this check probably had (and maybe still has?) a meaning, it's essential for the fix for the video id not getting overriden when watching shorts: https://canary.discord.com/channels/328493314485518336/745695354447462440/834493238898589766

from my testing, there were no exceptions after removing this check. however if you think it should stay there, i'll need to find another way, though realistically i can't imagine any concurrency issues there